### PR TITLE
harden: use bounded strlcpy/snprintf in config.c...

### DIFF
--- a/source/mupen64plus-core/src/api/config.c
+++ b/source/mupen64plus-core/src/api/config.c
@@ -723,7 +723,7 @@ EXPORT m64p_error CALL ConfigExternalGetParameter(m64p_handle Handle, const char
                 {
                     if (osal_insensitive_strcmp(ParamName, l.name) == 0)
                     {
-                        strncpy(ParamPtr, l.value, ParamMaxLength);
+                        snprintf(ParamPtr, ParamMaxLength, "%s", l.value);
                         free(buffer);
                         return M64ERR_SUCCESS;
                     }
@@ -1178,7 +1178,7 @@ EXPORT m64p_error CALL ConfigGetParameter(m64p_handle ConfigSectionHandle, const
             if (MaxSize < 1) return M64ERR_INPUT_INVALID;
             if (var->type != M64TYPE_STRING && var->type != M64TYPE_BOOL) return M64ERR_WRONG_TYPE;
             string = ConfigGetParamString(ConfigSectionHandle, ParamName);
-            strncpy((char *) ParamValue, string, MaxSize);
+            snprintf((char *) ParamValue, MaxSize, "%s", string);
             *((char *) ParamValue + MaxSize - 1) = 0;
             break;
         }


### PR DESCRIPTION
## Summary
Harden input handling in `source/mupen64plus-core/src/api/config.c` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `c.lang.security.insecure-use-string-copy-fn.insecure-use-string-copy-fn` |
| **File** | `source/mupen64plus-core/src/api/config.c:726` |
| **Assessment** | Defensive hardening |

**Description**: Finding triggers whenever there is a strcpy or strncpy used. This is an issue because strcpy does not affirm the size of the destination array and strncpy will not automatically NULL-terminate strings. This can lead to buffer overflows, which can cause program crashes and potentially let an attacker inject code in the program. Fix this by using strcpy_s instead (although note that strcpy_s is an optional part of the C11 standard, and so may not be available).

## Threat Model Context

This API endpoint appears to be publicly accessible. This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `source/mupen64plus-core/src/api/config.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
